### PR TITLE
adding @RequestBody to fix GenerateHistoryController::generate

### DIFF
--- a/src/main/java/com/deveficiente/complexitytracker/generatehistory/GenerateHistoryController.java
+++ b/src/main/java/com/deveficiente/complexitytracker/generatehistory/GenerateHistoryController.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
@@ -38,7 +39,7 @@ public class GenerateHistoryController {
 	@PostMapping(value = "/generate-history")
 	// 1
 	@ResponseBody
-	public ResponseEntity<?> generate(@Valid GenerateHistoryRequest request,
+	public ResponseEntity<?> generate(@Valid @RequestBody GenerateHistoryRequest request,
 			UriComponentsBuilder uriComponent) {
 
 		List<String> hashes = request.parseCommitsHashes();


### PR DESCRIPTION
When doing a POST to `/generate-history`, was getting a `400 Bad request` telling that all parameters were blank.

Added a `@RequestBody` to `GenerateHistoryController::generate` in order to fix this.